### PR TITLE
add PATCH method to endpoint base class

### DIFF
--- a/src/endpoint/MockEndpoint.coffee
+++ b/src/endpoint/MockEndpoint.coffee
@@ -9,6 +9,7 @@ module.exports = (Logger) ->
       PUT:"PUT"
       DELETE:"DELETE"
       POST:"POST"
+      PATCH: "PATCH"
     }
 
     configure: (app, webServer, useDefaults) ->


### PR DESCRIPTION
@acolchado We're using PATCH on our microapp, but the mock server doesn't support it yet. I've added it in this PR. Let me know if you'd like tests for this, but it's fully supported in express.