### PR TITLE
add v3 fixtures with andReturnJSON option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The Spur Framework is a collection of commonly used Node.JS libraries used to cr
     - [Usage](#usage)
       - [Standalone usage example](#standalone-usage-example)
       - [Mixed web app usage example](#mixed-web-app-usage-example)
+      - [Controlling fixtures from a browser client](#controlling-fixtures-from-a-browser-client)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -174,6 +175,42 @@ module.exports = (BaseWebServer, config)->
       @start()
 ```
 
+### Controlling fixtures from a browser client
+
+The `/v3/fixtures` middleware handler enables the customization of fixtures returned by mock endpoints from web browser clients, e.g. with `XMLHttpRequest` or `fetch`, addressing use cases of web UI developers and manual QA.
+
+#### Method
+
+```javascript
+var xhr = new XMLHttpRequest();
+xhr.open("POST", "http://localhost/v3/fixtures");
+xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+xhr.send(JSON.stringify({
+  fixtures: [{
+    endpoint: "MyMockEndpoint",
+    method: "myMethod"
+  }]
+}));
+```
+
+If the mock server is running on `localhost` and the mock endpoint `MyMockEndpoint` is registered and has a method `myMethod`, the `POST` request succeeds and successive requests that are handled by `MyMockEndpoint` will run `myMethod` to generate its response.
+
+#### JSON
+
+```javascript
+var xhr = new XMLHttpRequest();
+xhr.open("POST", "http://localhost/v3/fixtures");
+xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+xhr.send(JSON.stringify({
+  fixtures: [{
+    endpoint: "MyMockEndpoint",
+    json: {"example":[1, 2, 3]}
+  }]
+}));
+```
+
+If the mock server is running on `localhost` and the mock endpoint `MyMockEndpoint` is registered, the `POST` request succeeds and successive requests that are handled by `MyMockEndpoint` will respond with an HTTP status of `200` and the JSON  `{"example":[1, 2, 3]}`.
+
 # Contributing
 
 ## We accept pull requests
@@ -201,4 +238,3 @@ $ npm test
 # License
 
 [MIT](LICENSE)
-

--- a/src/webserver/MockWebServer.coffee
+++ b/src/webserver/MockWebServer.coffee
@@ -23,6 +23,7 @@ module.exports = (BaseWebServer, MockEndpointRegistration, Logger, ControllerReg
 
       @app.post "/fixtures", @handleFixtureRequest
       @app.post "/v2/fixtures", @handleFixtureRequestV2
+      @app.post "/v3/fixtures", @handleFixtureRequestV3
 
     handleFixtureRequest:(req, res)=>
       res.send _.map req.body.fixtures, @mapFixture
@@ -36,6 +37,16 @@ module.exports = (BaseWebServer, MockEndpointRegistration, Logger, ControllerReg
 
     mapFixtureV2:(fixture)=>
       @["#{fixture.endpoint}"].andCallMethod(fixture.method)
+      fixture
+
+    handleFixtureRequestV3:(req, res)=>
+      res.send _.map req.body.fixtures, @mapFixtureV3
+
+    mapFixtureV3:(fixture)=>
+      if fixture.json
+        @["#{fixture.endpoint}"].andReturnJSON(fixture.json)
+      else
+        @["#{fixture.endpoint}"].andCallMethod(fixture.method)
       fixture
 
     setUseDefaults:(@useDefaults = false)->

--- a/test/unit/endpoint/UsersMockEndpointSpec.coffee
+++ b/test/unit/endpoint/UsersMockEndpointSpec.coffee
@@ -47,3 +47,71 @@ describe "UsersMockEndpoint", ->
           expectedUser(results.users[0], 123, "John", "Doe")
           expectedUser(results.users[1], 124, "Jane", "Doe")
           expectedUser(results.users[2], 125, "Smith", "Doe")
+
+  describe "test V3 client-customized data calls", ->
+
+    beforeEach ->
+      @server.start()
+
+    afterEach ->
+      @server.stop()
+
+    generateUser = (id, firstName, lastName)->
+      {
+        id: id
+        firstName: firstName
+        lastName: lastName
+      }
+
+    expectedUser = (item, id, firstName, lastName)->
+      testItem = generateUser(id, firstName, lastName)
+      expect(item).to.deep.equal(testItem)
+
+    it "should resolve with 3 results", ()->
+      @HTTPService
+        .post("http://localhost:#{@config.Port}/v3/fixtures/")
+        # .type('json')
+        .send({
+          fixtures: [{
+            endpoint: "UsersMockEndpoint"
+            method: "withThree"
+          }]
+        })
+        .promiseBody()
+        .then =>
+          @HTTPService
+            .get("http://localhost:#{@config.Port}/api/users/")
+            .promiseBody()
+            .then (results)->
+
+              expect(results.users.length)
+
+              expectedUser(results.users[0], 123, "John", "Doe")
+              expectedUser(results.users[1], 124, "Jane", "Doe")
+              expectedUser(results.users[2], 125, "Smith", "Doe")
+
+    it "should resolve with 2 results", ()->
+      @HTTPService
+        .post("http://localhost:#{@config.Port}/v3/fixtures/")
+        .send({
+          fixtures: [{
+            endpoint: "UsersMockEndpoint"
+            json: {
+              users: [
+                generateUser(789, "Testin", "Testerfield"),
+                generateUser(910, "Testelle", "McTesting")
+              ]
+            }
+          }]
+        })
+        .promiseBody()
+        .then =>
+          @HTTPService
+            .get("http://localhost:#{@config.Port}/api/users/")
+            .promiseBody()
+            .then (results)->
+
+              expect(results.users.length)
+
+              expectedUser(results.users[0], 789, "Testin", "Testerfield")
+              expectedUser(results.users[1], 910, "Testelle", "McTesting")


### PR DESCRIPTION
### Summary

Adds `/v3/fixtures` with an option to utilize `andReturnJSON` functionality of mock endpoints.

### Purpose

The three "fixtures" middleware handlers enable the customization of fixtures returned by mock endpoints from web clients, e.g. with `XMLHttpRequest` or `fetch`, addressing use cases of web UI developers and manual QA.

The existing `/fixtures` and `/v2/fixtures` handlers enable the selection of a pre-existing method from mock endpoints. This pull requests creates a `/v3/fixtures` handler that enables a user to set an explicit complete response in JSON, giving the web client interface functional parity (basically, also see further about status) with the Node.js runtime interface in controlling mock endpoint responses. 

### Previous Usage

On a web page used for active development or testing,

```javascript
var xhr = new XMLHttpRequest();
xhr.open("POST", "http://localhost/v2/fixtures");
xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
xhr.send(JSON.stringify({
  fixtures: [{
    endpoint: "MyMockEndpoint",
    method: "myMethod"
  }]
}));
```

If the mock server is running on `localhost` and the mock endpoint `MyMockEndpoint` is registered and has a method `myMethod`, the `POST` request succeeds and successive requests that are handled by `MyMockEndpoint` will run `myMethod` to generate its response.

### New Usage

#### Method

```javascript
var xhr = new XMLHttpRequest();
xhr.open("POST", "http://localhost/v3/fixtures");
xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
xhr.send(JSON.stringify({
  fixtures: [{
    endpoint: "MyMockEndpoint",
    method: "myMethod"
  }]
}));
```

If the mock server is running on `localhost` and the mock endpoint `MyMockEndpoint` is registered and has a method `myMethod`, the `POST` request succeeds and successive requests that are handled by `MyMockEndpoint` will run `myMethod` to generate its response.

#### JSON

```javascript
var xhr = new XMLHttpRequest();
xhr.open("POST", "http://localhost/v3/fixtures");
xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
xhr.send(JSON.stringify({
  fixtures: [{
    endpoint: "MyMockEndpoint",
    json: {"example":[1, 2, 3]}
  }]
}));
```

If the mock server is running on `localhost` and the mock endpoint `MyMockEndpoint` is registered, the `POST` request succeeds and successive requests that are handled by `MyMockEndpoint` will respond with an HTTP status of `200` and the JSON  `{"example":[1, 2, 3]}`.

##### Status (optional)

Removed due to bug (see comments).